### PR TITLE
fix InfluxDB port in startup.sh

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -5,9 +5,9 @@ echo "Version: $COMMIT_VERSION - $COMMIT_TIME"
 echo "----------------"
 
 # Wait for InfluxDB
-until nc -z -v -w30 "$INFLUX_HOST" 8086
+until nc -z -v -w30 "$INFLUX_HOST" ${INFLUX_PORT:-8086}
 do
-  echo "Waiting for InfluxDB on $INFLUX_HOST:8086 ..."
+  echo "Waiting for InfluxDB on $INFLUX_HOST:${INFLUX_PORT:-8086} ..."
   sleep 1
 done
 echo "InfluxDB is up and running!"


### PR DESCRIPTION
When using an existing external InfluxDB-instance, which might not run on port 8086, the startup-script fails to check the InfluxDB (it won't come to an end), so the port from the env-file is used and 8086 only as fallback