### PR TITLE
Make CO₂ emissions factor configurable

### DIFF
--- a/app/components/essentials_tile/component.rb
+++ b/app/components/essentials_tile/component.rb
@@ -93,7 +93,7 @@ class EssentialsTile::Component < ViewComponent::Base
     when :savings
       t("calculator.#{sensor}")
     when :co2_reduction
-      t('calculator.co2_reduction_note')
+      t('calculator.co2_reduction_note', co2_emission_factor: Rails.configuration.x.co2_emission_factor)
     else
       t("sensors.#{sensor}")
     end

--- a/app/components/stats_range/component.html.slim
+++ b/app/components/stats_range/component.html.slim
@@ -41,7 +41,7 @@
                   turbo_prefetch: 'false',
                 },
                 class: 'click-animation' do
-        div data-controller="tippy" title= t('calculator.co2_reduction_note')
+        div data-controller="tippy" title= t('calculator.co2_reduction_note', co2_emission_factor: Rails.configuration.x.co2_emission_factor)
           = render RadialBadge::Component.new(title: t('calculator.co2_reduction')) do
             = Number::Component.new(value: calculator.co2_reduction).to_weight(klass: 'text-sky-700')
 

--- a/app/services/calculator/range.rb
+++ b/app/services/calculator/range.rb
@@ -1,6 +1,6 @@
 class Calculator::Range < Calculator::Base
-  CO2_EMISION_FACTOR = 401 # g / kWh
-  public_constant :CO2_EMISION_FACTOR
+  CO2_EMISSION_FACTOR = Rails.application.config.x.co2_emission_factor
+  public_constant :CO2_EMISSION_FACTOR
 
   def initialize(timeframe)
     super()
@@ -112,7 +112,7 @@ class Calculator::Range < Calculator::Base
   def co2_reduction
     return unless inverter_power
 
-    inverter_power / 1000 * CO2_EMISION_FACTOR
+    inverter_power / 1000 * CO2_EMISSION_FACTOR
   end
 
   def battery_savings

--- a/app/services/chart_data/co2_reduction.rb
+++ b/app/services/chart_data/co2_reduction.rb
@@ -17,7 +17,7 @@ class ChartData::Co2Reduction < ChartData::Base
   end
 
   def co2_reduction_factor
-    Calculator::Range::CO2_EMISION_FACTOR.fdiv(
+    Calculator::Range::CO2_EMISSION_FACTOR.fdiv(
       if timeframe.short?
         # g per hour
         24.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,7 @@ module Solectrus
     config.x.plausible_url = ENV['PLAUSIBLE_URL'].presence
     config.x.honeybadger.api_key = ENV['HONEYBADGER_API_KEY'].presence
     config.x.rorvswild.api_key = ENV['RORVSWILD_API_KEY'].presence
+    config.x.co2_emission_factor = ENV.fetch('CO2_EMISSION_FACTOR', 401).to_i # g / kWh
 
     config.x.influx.token = ENV.fetch('INFLUX_TOKEN', nil)
     config.x.influx.schema = ENV.fetch('INFLUX_SCHEMA', 'http')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -59,7 +59,7 @@ de:
     traditional_price: Vergleichspreis
     savings: Einsparung
     co2_reduction: CO₂-Reduktion
-    co2_reduction_note: Reduzierung der CO₂-Emissionen durch die Stromerzeugung gegenüber dem deutschen Strommix (401 g/kWh).
+    co2_reduction_note: Reduzierung der CO₂-Emissionen durch die Stromerzeugung gegenüber dem angegebenen Faktor (%{co2_emission_factor} g/kWh).
     battery_savings: Anteil Akku
     house_costs: Anteil Haus
     wallbox_costs: Anteil E-Auto

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
     traditional_price: Comparative price
     savings: Savings
     co2_reduction: CO₂ reduction
-    co2_reduction_note: Reduction in CO₂ emissions from PV generation compared to the German electricity mix (401 g/kWh)
+    co2_reduction_note: Reduction in CO₂ emissions from PV generation compared to the current CO₂ emission factor (%{co2_emission_factor} g/kWh)
     battery_savings: Battery share
     house_costs: House costs
     wallbox_costs: EV costs


### PR DESCRIPTION
I love the CO₂ reduction feature, but it is not configurable, and set to the German factor, which is, to be honest, quite high (thanks Grünen). 

This PR allows the factor to be set as an ENV variable. Ideally it would work just as the energy prices, with a set start date for the calculations, so that you can update it when new energy sources are introduced, but that is too much work for now. I might look further into in the future, but for the time being this works. 

Also fixes a typo with the constant name.