### PR TITLE
feat(prices): configurable currency via ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ WEB_CONCURRENCY=0
 # Optional: CO2 emission factor in g/kWh (default: 401)
 # CO2_EMISSION_FACTOR=401
 
+# Optional: Currency as ISO-4217 code (default: EUR), e.g. CHF, USD
+# CURRENCY=EUR
+
 # Optional: Set static UI theme ('light' or 'dark', omit for auto-detection)
 # UI_THEME=
 

--- a/app/components/chart_loader/component.html.slim
+++ b/app/components/chart_loader/component.html.slim
@@ -10,6 +10,7 @@
               controller: 'chart-loader--component chart-zoom',
               chart_loader__component_type_value: type,
               chart_loader__component_unit_value: unit,
+              chart_loader__component_currency_value: currency,
               chart_loader__component_source_label_value: I18n.t('balance_sheet.left'),
               chart_loader__component_usage_label_value: I18n.t('balance_sheet.right'),
               chart_zoom_zoom_interval_value: zoom_interval,

--- a/app/components/chart_loader/component.rb
+++ b/app/components/chart_loader/component.rb
@@ -25,6 +25,10 @@ class ChartLoader::Component < ViewComponent::Base
     I18n.t('data.blank')
   end
 
+  def currency
+    Currency.symbol
+  end
+
   def path_to_insights
     return if timeframe.now?
     return unless sensor.trendable?

--- a/app/components/chart_loader/component_controller.ts
+++ b/app/components/chart_loader/component_controller.ts
@@ -107,6 +107,7 @@ export default class extends Controller<HTMLCanvasElement> {
   static readonly values = {
     type: String,
     unit: String,
+    currency: String,
     sourceLabel: String,
     usageLabel: String,
   };
@@ -126,6 +127,9 @@ export default class extends Controller<HTMLCanvasElement> {
 
   declare unitValue: string;
   declare readonly hasUnitValue: boolean;
+
+  declare currencyValue: string;
+  declare readonly hasCurrencyValue: boolean;
 
   declare sourceLabelValue: string;
   declare readonly hasSourceLabelValue: boolean;
@@ -409,6 +413,7 @@ export default class extends Controller<HTMLCanvasElement> {
       target,
       autoKilo,
       unitValue: this.unitValue,
+      currency: this.currencyValue,
       locale: this.locale,
       minValue,
       maxValue,

--- a/app/components/chart_loader/helpers/formatting.ts
+++ b/app/components/chart_loader/helpers/formatting.ts
@@ -5,6 +5,7 @@ type FormatOptions = {
   target?: FormatTarget;
   autoKilo?: boolean;
   unitValue: string;
+  currency: string;
   locale: string;
   minValue: number;
   maxValue: number;
@@ -14,7 +15,7 @@ type FormatOptions = {
 export const getDecimalPlaces = (
   target: FormatTarget,
   kilo: boolean,
-  isEuro: boolean,
+  isCurrency: boolean,
   unitValue: string,
   minValue: number,
   maxValue: number,
@@ -28,7 +29,7 @@ export const getDecimalPlaces = (
     return { minDecimals: 0, maxDecimals };
   }
 
-  if (isEuro) {
+  if (isCurrency) {
     const showDecimals =
       target === 'axis' ? maxValue < 10 : minValue < 10 && maxValue < 100;
     const decimals = showDecimals ? 2 : 0;
@@ -46,18 +47,19 @@ export const formatNumber = (
     target = 'tooltip',
     autoKilo = true,
     unitValue,
+    currency,
     locale,
     minValue,
     maxValue,
   }: FormatOptions,
 ): string => {
   let unitValuePrefix = '';
-  const isEuro = unitValue.includes('€');
+  const isCurrency = currency !== '' && unitValue.includes(currency);
 
   // Decide the kilo prefix chart-wide from the axis range (not per value), so
   // every tooltip line and axis tick shares the same unit (e.g. all kWh, never
   // a mix of "48 kWh" and "464 Wh").
-  const kilo = autoKilo && !isEuro && (maxValue > 1000 || minValue < -1000);
+  const kilo = autoKilo && !isCurrency && (maxValue > 1000 || minValue < -1000);
   if (kilo) {
     number /= 1000.0;
     unitValuePrefix = 'k';
@@ -66,7 +68,7 @@ export const formatNumber = (
   const { minDecimals, maxDecimals } = getDecimalPlaces(
     target,
     kilo,
-    isEuro,
+    isCurrency,
     unitValue,
     minValue,
     maxValue,

--- a/app/components/price_list/component.html.slim
+++ b/app/components/price_list/component.html.slim
@@ -18,7 +18,7 @@
         .md:table-cell.align-middle.p-2.text-gray-500.text-sm.pl-5.hidden
           = price.note
         .table-cell.align-middle.p-2.tabular-nums.text-right.w-1.whitespace-nowrap
-          = number_to_currency(price.value, precision: nil)
+          = number_to_currency(price.value, precision: nil, unit: Currency.symbol)
         .table-cell.align-middle.p-2.tabular-nums.w-10.text-right.text-sm.whitespace-nowrap
           = relative_change(price, index)
 

--- a/app/lib/currency.rb
+++ b/app/lib/currency.rb
@@ -1,0 +1,22 @@
+# Maps an ISO-4217 currency code (configured via the CURRENCY env var) to the
+# symbol shown in the UI. Codes without a common symbol fall back to the code
+# itself (e.g. "CHF" stays "CHF", rendered as "CHF/kWh").
+module Currency
+  SYMBOLS = {
+    'EUR' => '€',
+    'USD' => '$',
+    'GBP' => '£',
+    'JPY' => '¥',
+    'CNY' => '¥',
+    'INR' => '₹',
+  }.freeze
+  private_constant :SYMBOLS
+
+  def self.code
+    Rails.configuration.x.currency
+  end
+
+  def self.symbol(currency_code = code)
+    SYMBOLS.fetch(currency_code, currency_code)
+  end
+end

--- a/app/lib/sensor/chart/finance_base.rb
+++ b/app/lib/sensor/chart/finance_base.rb
@@ -3,7 +3,7 @@ class Sensor::Chart::FinanceBase < Sensor::Chart::Base
     [finance_sensor_name]
   end
 
-  # Override unit to always show EUR
+  # Override unit to always show the configured currency
   def unit
     @unit ||=
       Sensor::UnitFormatter.format(

--- a/app/lib/sensor/unit_formatter.rb
+++ b/app/lib/sensor/unit_formatter.rb
@@ -6,7 +6,7 @@ class Sensor::UnitFormatter
 
   # @param unit [Symbol] The unit type from sensor
   # @param value [Numeric, nil] Optional value for auto-scaling (watt, gram)
-  # @param context [Symbol] :rate (W, g/h, EUR/h) or :total (Wh, g, EUR)
+  # @param context [Symbol] :rate (W, g/h, currency/h) or :total (Wh, g, currency)
   # @param scaling [Symbol, Numeric] :auto, :off, :kilo, :mega, or explicit number
   def initialize(unit:, value: nil, context: :rate, scaling: :auto)
     @unit = unit
@@ -71,9 +71,9 @@ class Sensor::UnitFormatter
     when :percent
       '%'
     when :euro
-      context == :rate ? '€/h' : '€'
+      context == :rate ? "#{Currency.symbol}/h" : Currency.symbol
     when :euro_per_kwh
-      '€/kWh'
+      "#{Currency.symbol}/kWh"
     else
       ''
     end

--- a/app/views/settings/prices/_form.html.slim
+++ b/app/views/settings/prices/_form.html.slim
@@ -7,7 +7,7 @@
     = f.number_field :value,
                      in: 0..2,
                      step: '0.00001',
-                     label: t("activerecord.attributes.price.#{price.name}_amount").html_safe
+                     label: t("activerecord.attributes.price.#{price.name}_amount", currency: Currency.symbol)
     = f.text_field :note
 
   .flex.justify-end

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,7 @@ services:
       - ADMIN_PASSWORD
       - FRAME_ANCESTORS
       - CO2_EMISSION_FACTOR
+      - CURRENCY
       - DB_HOST
       - DB_PASSWORD=${POSTGRES_PASSWORD}
       - DB_USER

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,6 +69,7 @@ module Solectrus
     config.x.honeybadger.api_key = ENV['HONEYBADGER_API_KEY'].presence
     config.x.rorvswild.api_key = ENV['RORVSWILD_API_KEY'].presence
     config.x.co2_emission_factor = ENV.fetch('CO2_EMISSION_FACTOR', 401).to_i # g / kWh
+    config.x.currency = ENV.fetch('CURRENCY', 'EUR').to_s.strip.upcase.presence || 'EUR' # ISO-4217 code, e.g. EUR, CHF, USD
 
     config.x.influx.token = ENV.fetch('INFLUX_TOKEN', nil)
     config.x.influx.schema = ENV.fetch('INFLUX_SCHEMA', 'http')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -287,8 +287,8 @@ de:
         starts_at: Gültig ab
         value: Betrag
         note: Notiz
-        electricity_amount: Arbeitspreis in &euro;/kWh
-        feed_in_amount: Vergütungssatz in &euro;/kWh
+        electricity_amount: Arbeitspreis in %{currency}/kWh
+        feed_in_amount: Vergütungssatz in %{currency}/kWh
       setting:
         plant_name: Bezeichnung der Anlage
         operator_name: Name des Betreibers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,8 +287,8 @@ en:
         starts_at: Effective from
         value: Amount
         note: Note
-        electricity_amount: Rate in &euro;/kWh
-        feed_in_amount: Rate in &euro;/kWh
+        electricity_amount: Rate in %{currency}/kWh
+        feed_in_amount: Rate in %{currency}/kWh
       setting:
         plant_name: Name of the plant
         operator_name: Name of the operator

--- a/spec/lib/currency_spec.rb
+++ b/spec/lib/currency_spec.rb
@@ -1,0 +1,36 @@
+describe Currency do
+  describe '.code' do
+    subject { described_class.code }
+
+    before { allow(Rails.configuration.x).to receive(:currency).and_return('CHF') }
+
+    it { is_expected.to eq('CHF') }
+  end
+
+  describe '.symbol' do
+    subject { described_class.symbol }
+
+    context 'when the configured currency has a known symbol' do
+      before { allow(Rails.configuration.x).to receive(:currency).and_return('USD') }
+
+      it { is_expected.to eq('$') }
+    end
+
+    context 'when the configured currency has no known symbol' do
+      before { allow(Rails.configuration.x).to receive(:currency).and_return('CHF') }
+
+      it 'falls back to the code itself' do
+        is_expected.to eq('CHF')
+      end
+    end
+
+    context 'with the default currency' do
+      it { is_expected.to eq('€') }
+    end
+
+    context 'with an explicit code' do
+      it { expect(described_class.symbol('GBP')).to eq('£') }
+      it { expect(described_class.symbol('SEK')).to eq('SEK') }
+    end
+  end
+end

--- a/spec/lib/sensor/value_formatter_spec.rb
+++ b/spec/lib/sensor/value_formatter_spec.rb
@@ -56,6 +56,12 @@ describe Sensor::ValueFormatter do
       formatter = described_class.new(15.5, unit: :euro)
       expect(formatter.to_s).to eq('16 €')
     end
+
+    it 'uses the configured currency symbol' do
+      allow(Rails.configuration.x).to receive(:currency).and_return('CHF')
+      formatter = described_class.new(0.25, unit: :euro_per_kwh)
+      expect(formatter.to_s).to eq('0,2500 CHF/kWh')
+    end
   end
 
   describe 'unit type handling' do


### PR DESCRIPTION
Add a CURRENCY env var (ISO-4217 code, default EUR) that replaces the hardcoded euro symbol in unit formatting, price list, finance charts and the price form label. Codes without a known symbol fall back to the code itself (e.g. CHF -> "CHF/kWh"). The chart frontend now detects currency generically instead of matching the euro sign.

Closes #2797